### PR TITLE
Disable auto-detection JDK/JRE

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,5 @@ auth-server.client-id=
 auth-server.client-secret=
 employee-service.user=
 employee-service.password=
+
+org.gradle.java.installations.auto-detect=false


### PR DESCRIPTION
To avoid a side effect in the compilation process kotlin 1.8 in the JDK 11