### PR TITLE
Add health check for the report

### DIFF
--- a/server/src/main/kotlin/org/octopusden/employee/actuator/OneCReportHealthIndicator.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/actuator/OneCReportHealthIndicator.kt
@@ -2,6 +2,7 @@ package org.octopusden.employee.actuator
 
 import org.octopusden.employee.config.OneCProperties
 import org.octopusden.employee.service.onec.client.OneCClient
+import org.slf4j.LoggerFactory
 import org.springframework.boot.actuate.health.Health
 import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.stereotype.Component
@@ -30,7 +31,12 @@ class OneCReportHealthIndicator(
                 Health.up().build()
             }
         } catch (e: Exception) {
+            logger.error("Error during health check", e)
             Health.down(e).build()
         }
+    }
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(OneCReportHealthIndicator::class.java)
     }
 }

--- a/server/src/main/kotlin/org/octopusden/employee/actuator/OneCReportHealthIndicator.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/actuator/OneCReportHealthIndicator.kt
@@ -1,0 +1,36 @@
+package org.octopusden.employee.actuator
+
+import org.octopusden.employee.config.OneCProperties
+import org.octopusden.employee.service.onec.client.OneCClient
+import org.springframework.boot.actuate.health.Health
+import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.stereotype.Component
+
+/**
+ * The component to check integration wit oneC report
+ */
+@Component
+class OneCReportHealthIndicator(
+    private val oneCProperties: OneCProperties,
+    private val oneCClient: OneCClient
+) : HealthIndicator {
+
+    override fun health(): Health {
+        val health = oneCProperties.health ?: return Health.unknown().build()
+        return try {
+            val result = oneCClient.getPlannedTime(health.user, health.startDate, health.endDate)
+            if (result.isEmpty()) {
+                Health.down()
+                    .withDetail(
+                        "error",
+                        "No data for user ${health.user} in period ${health.startDate} - ${health.endDate}"
+                    )
+                    .build()
+            } else {
+                Health.up().build()
+            }
+        } catch (e: Exception) {
+            Health.down(e).build()
+        }
+    }
+}

--- a/server/src/main/kotlin/org/octopusden/employee/config/OneCProperties.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/OneCProperties.kt
@@ -1,8 +1,23 @@
 package org.octopusden.employee.config
 
+import java.time.LocalDate
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
+import org.springframework.format.annotation.DateTimeFormat
 
 @ConfigurationProperties("one-c")
 @ConstructorBinding
-data class OneCProperties(val host: String, val username: String, val password: String)
+data class OneCProperties(
+    val host: String,
+    val username: String,
+    val password: String,
+    val health: Health? = null
+) {
+    data class Health(
+        val user: String,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        val startDate: LocalDate,
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        val endDate: LocalDate
+    )
+}


### PR DESCRIPTION
Data integrity in the report from 1C is being checked

Example of configuration setup:
```yaml
one-c:
  health:
    user: ivanov.                      # Username for whom the report is requested
    startDate: 2021-09-01
    endDate: 2021-09-02
```