### PR TITLE
Make HTTP connect/read timeouts configurable via EmployeeServiceClientParametersProvider

### DIFF
--- a/client/src/main/kotlin/org/octopusden/employee/client/impl/ClassicEmployeeServiceClient.kt
+++ b/client/src/main/kotlin/org/octopusden/employee/client/impl/ClassicEmployeeServiceClient.kt
@@ -74,7 +74,11 @@ class ClassicEmployeeServiceClient(
         ): EmployeeServiceClient {
             return Feign.builder()
                 .client(ApacheHttpClient())
-                .options(Request.Options(5, TimeUnit.MINUTES, 5, TimeUnit.MINUTES, true))
+                .options(Request.Options(
+                    parametersProvider.getConnectTimeoutMillis().toLong(), TimeUnit.MILLISECONDS,
+                    parametersProvider.getReadTimeoutMillis().toLong(), TimeUnit.MILLISECONDS,
+                    true
+                ))
                 .encoder(JacksonEncoder(objectMapper))
                 .decoder(JacksonDecoder(objectMapper))
                 .errorDecoder(EmployeeServiceErrorDecoder(objectMapper))

--- a/client/src/main/kotlin/org/octopusden/employee/client/impl/ClassicEmployeeServiceClient.kt
+++ b/client/src/main/kotlin/org/octopusden/employee/client/impl/ClassicEmployeeServiceClient.kt
@@ -14,6 +14,7 @@ import feign.Feign
 import feign.Logger
 import feign.Request
 import feign.httpclient.ApacheHttpClient
+import org.apache.http.impl.client.HttpClientBuilder
 import feign.jackson.JacksonDecoder
 import feign.jackson.JacksonEncoder
 import feign.slf4j.Slf4jLogger
@@ -73,7 +74,14 @@ class ClassicEmployeeServiceClient(
             objectMapper: ObjectMapper,
         ): EmployeeServiceClient {
             return Feign.builder()
-                .client(ApacheHttpClient())
+                .client(ApacheHttpClient(
+                    HttpClientBuilder.create()
+                        .apply {
+                            if (parametersProvider.getConnectionTtlMillis() >= 0)
+                                setConnectionTimeToLive(parametersProvider.getConnectionTtlMillis().toLong(), TimeUnit.MILLISECONDS)
+                        }
+                        .build()
+                ))
                 .options(Request.Options(
                     parametersProvider.getConnectTimeoutMillis().toLong(), TimeUnit.MILLISECONDS,
                     parametersProvider.getReadTimeoutMillis().toLong(), TimeUnit.MILLISECONDS,

--- a/client/src/main/kotlin/org/octopusden/employee/client/impl/EmployeeServiceClientParametersProvider.kt
+++ b/client/src/main/kotlin/org/octopusden/employee/client/impl/EmployeeServiceClientParametersProvider.kt
@@ -5,4 +5,6 @@ interface EmployeeServiceClientParametersProvider {
     fun getApiUrl(): String
     fun getTimeRetryInMillis(): Int
     fun getBasicCredentials(): String?
+    fun getConnectTimeoutMillis(): Int = 300_000
+    fun getReadTimeoutMillis(): Int = 300_000
 }

--- a/client/src/main/kotlin/org/octopusden/employee/client/impl/EmployeeServiceClientParametersProvider.kt
+++ b/client/src/main/kotlin/org/octopusden/employee/client/impl/EmployeeServiceClientParametersProvider.kt
@@ -7,4 +7,5 @@ interface EmployeeServiceClientParametersProvider {
     fun getBasicCredentials(): String?
     fun getConnectTimeoutMillis(): Int = 300_000
     fun getReadTimeoutMillis(): Int = 300_000
+    fun getConnectionTtlMillis(): Int = -1
 }


### PR DESCRIPTION
## Summary

Two improvements to `ClassicEmployeeServiceClient` HTTP client configuration, both fully backward compatible.

### 1. Configurable connect/read timeouts (closes #58)

- Add `getConnectTimeoutMillis()` and `getReadTimeoutMillis()` to `EmployeeServiceClientParametersProvider` with defaults of `300_000` ms (5 min) that preserve existing behavior
- Replace the hardcoded `Request.Options(5, TimeUnit.MINUTES, ...)` with values from the parameters provider
- Consumers that need shorter timeouts (e.g. health check endpoints) override the methods in their implementation

### 2. Configurable connection TTL

- Add `getConnectionTtlMillis()` to `EmployeeServiceClientParametersProvider` with default `-1` (no TTL — preserves current behavior of infinite connection lifetime)
- When overridden to a non-negative value, `HttpClientBuilder.setConnectionTimeToLive()` is applied so stale connections are automatically evicted within one TTL window
- Fixes intermittent `Connection refused` / `Connection reset` errors after server migrations, without requiring a manual `updateConnection()` call

## Motivation

Closes #58

Both issues surfaced during the Keycloak OOM incident:
- 5-minute timeouts caused Tomcat thread pool exhaustion (500 stuck threads)
- No connection TTL caused stale pool false-positive health checks after infrastructure changes

## Backward compatibility

- Timeout defaults (`300_000` ms) preserve the current 5-minute behavior
- TTL default (`-1`) preserves the current infinite connection lifetime
- Existing consumers need no changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employee service client now applies configurable connection and read timeouts at runtime.
  * Added default timeout settings for connection, read, and optional connection TTL to reduce manual configuration.

* **Bug Fixes**
  * Removed fixed timeout behavior by aligning client request timing with configured (or default) values, improving consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->