### PR TITLE
Add GET /employee/{username}/manager endpoint

### DIFF
--- a/client/src/main/kotlin/org/octopusden/employee/client/EmployeeServiceClient.kt
+++ b/client/src/main/kotlin/org/octopusden/employee/client/EmployeeServiceClient.kt
@@ -6,6 +6,7 @@ import feign.RequestLine
 import org.octopusden.employee.client.common.dto.CustomerDTO
 import org.octopusden.employee.client.common.dto.Employee
 import org.octopusden.employee.client.common.dto.Health
+import org.octopusden.employee.client.common.dto.ManagerDTO
 import org.octopusden.employee.client.common.dto.RequiredTimeDTO
 import org.octopusden.employee.client.common.dto.ServerInfo
 import org.octopusden.employee.client.common.dto.WorkingDaysDTO
@@ -46,6 +47,10 @@ interface EmployeeServiceClient {
         @Param("fromDate", expander = LocalDateExpander::class) fromDate: LocalDate,
         @Param("toDate", expander = LocalDateExpander::class) toDate: LocalDate
     ): WorkingDaysDTO
+
+    @Throws(NotFoundException::class)
+    @RequestLine("GET employee/{employee}/manager")
+    fun getManager(@Param("employee") employee: String): ManagerDTO
 
     @RequestLine("GET actuator/health/oneC")
     fun oneCHealth(): Health

--- a/client/src/main/kotlin/org/octopusden/employee/client/impl/ClassicEmployeeServiceClient.kt
+++ b/client/src/main/kotlin/org/octopusden/employee/client/impl/ClassicEmployeeServiceClient.kt
@@ -8,6 +8,7 @@ import org.octopusden.employee.client.EmployeeServiceErrorDecoder
 import org.octopusden.employee.client.EmployeeServiceRetry
 import org.octopusden.employee.client.common.dto.CustomerDTO
 import org.octopusden.employee.client.common.dto.Employee
+import org.octopusden.employee.client.common.dto.ManagerDTO
 import org.octopusden.employee.client.common.dto.RequiredTimeDTO
 import org.octopusden.employee.client.common.dto.ServerInfo
 import feign.Feign
@@ -57,6 +58,8 @@ class ClassicEmployeeServiceClient(
     fun updateApiParameters(apiParametersProvider: EmployeeServiceClientParametersProvider) {
         client = createClient(apiParametersProvider, mapper)
     }
+
+    override fun getManager(employee: String): ManagerDTO = client.getManager(employee)
 
     override fun oneCHealth(): Health = client.oneCHealth()
 

--- a/common/src/main/kotlin/org/octopusden/employee/client/common/dto/ManagerDTO.kt
+++ b/common/src/main/kotlin/org/octopusden/employee/client/common/dto/ManagerDTO.kt
@@ -1,0 +1,6 @@
+package org.octopusden.employee.client.common.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ManagerDTO(val manager: String?)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -172,6 +172,10 @@ dependencies {
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${project.properties["jackson.version"]}")
 
+    implementation("org.springframework.ldap:spring-ldap-core")
+    implementation("org.springframework.boot:spring-boot-starter-cache")
+    implementation("com.github.ben-manes.caffeine:caffeine")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation(project(":test-common"))

--- a/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
@@ -1,12 +1,16 @@
 package org.octopusden.employee.config
 
+import com.github.benmanes.caffeine.cache.Caffeine
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.ldap.core.LdapTemplate
 import org.springframework.ldap.core.support.LdapContextSource
+import java.util.concurrent.TimeUnit
 
 @Configuration
 @EnableCaching
@@ -27,4 +31,9 @@ class AdConfig(private val adProperties: AdProperties) {
         LdapTemplate(contextSource).apply {
             setIgnorePartialResultException(true)
         }
+
+    @Bean
+    fun cacheManager(): CacheManager = CaffeineCacheManager("managers").apply {
+        setCaffeine(Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(5, TimeUnit.MINUTES))
+    }
 }

--- a/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
@@ -1,0 +1,30 @@
+package org.octopusden.employee.config
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.ldap.core.LdapTemplate
+import org.springframework.ldap.core.support.LdapContextSource
+
+@Configuration
+@EnableCaching
+@EnableConfigurationProperties(AdProperties::class)
+@ConditionalOnProperty("ad.url")
+class AdConfig(private val adProperties: AdProperties) {
+
+    @Bean
+    fun ldapContextSource(): LdapContextSource = LdapContextSource().apply {
+        setUrl(adProperties.url)
+        setUserDn(adProperties.userDn)
+        setPassword(adProperties.password)
+        afterPropertiesSet()
+    }
+
+    @Bean
+    fun ldapTemplate(contextSource: LdapContextSource): LdapTemplate =
+        LdapTemplate(contextSource).apply {
+            setIgnorePartialResultException(true)
+        }
+}

--- a/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
@@ -23,6 +23,12 @@ class AdConfig(private val adProperties: AdProperties) {
         setUrl(adProperties.url)
         setUserDn(adProperties.userDn)
         setPassword(adProperties.password)
+        setBaseEnvironmentProperties(
+            mapOf(
+                "com.sun.jndi.ldap.connect.timeout" to CONNECT_TIMEOUT_MS.toString(),
+                "com.sun.jndi.ldap.read.timeout" to READ_TIMEOUT_MS.toString(),
+            )
+        )
         afterPropertiesSet()
     }
 
@@ -35,5 +41,10 @@ class AdConfig(private val adProperties: AdProperties) {
     @Bean
     fun cacheManager(): CacheManager = CaffeineCacheManager("managers").apply {
         setCaffeine(Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(5, TimeUnit.MINUTES))
+    }
+
+    companion object {
+        private const val CONNECT_TIMEOUT_MS = 5_000
+        private const val READ_TIMEOUT_MS = 10_000
     }
 }

--- a/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/AdConfig.kt
@@ -1,6 +1,7 @@
 package org.octopusden.employee.config
 
 import com.github.benmanes.caffeine.cache.Caffeine
+import org.octopusden.employee.service.impl.AdServiceImpl
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cache.CacheManager
@@ -39,7 +40,7 @@ class AdConfig(private val adProperties: AdProperties) {
         }
 
     @Bean
-    fun cacheManager(): CacheManager = CaffeineCacheManager("managers").apply {
+    fun cacheManager(): CacheManager = CaffeineCacheManager(AdServiceImpl.CACHE_MANAGERS).apply {
         setCaffeine(Caffeine.newBuilder().maximumSize(1000).expireAfterWrite(5, TimeUnit.MINUTES))
     }
 

--- a/server/src/main/kotlin/org/octopusden/employee/config/AdProperties.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/AdProperties.kt
@@ -1,0 +1,11 @@
+package org.octopusden.employee.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties("ad")
+data class AdProperties(
+    val url: String,
+    val userDn: String,
+    val password: String,
+    val baseDn: String,
+)

--- a/server/src/main/kotlin/org/octopusden/employee/config/AdProperties.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/AdProperties.kt
@@ -8,4 +8,7 @@ data class AdProperties(
     val userDn: String = "",
     val password: String = "",
     val baseDn: String = "",
-)
+) {
+    override fun toString(): String =
+        "AdProperties(url='$url', userDn='$userDn', password='***', baseDn='$baseDn')"
+}

--- a/server/src/main/kotlin/org/octopusden/employee/config/AdProperties.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/config/AdProperties.kt
@@ -4,8 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties("ad")
 data class AdProperties(
-    val url: String,
-    val userDn: String,
-    val password: String,
-    val baseDn: String,
+    val url: String = "",
+    val userDn: String = "",
+    val password: String = "",
+    val baseDn: String = "",
 )

--- a/server/src/main/kotlin/org/octopusden/employee/controller/EmployeeController.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/controller/EmployeeController.kt
@@ -1,6 +1,7 @@
 package org.octopusden.employee.controller
 
 import org.octopusden.employee.client.common.dto.Employee
+import org.octopusden.employee.client.common.dto.ManagerDTO
 import org.octopusden.employee.client.common.dto.RequiredTimeDTO
 import org.octopusden.employee.service.EmployeeService
 import org.springframework.security.access.annotation.Secured
@@ -34,4 +35,8 @@ class EmployeeController(
     @GetMapping("{username}/available")
     @PreAuthorize("@employeeServicePermissionEvaluator.hasPermission('ACCESS_EMPLOYEE')")
     fun isEmployeeAvailable(@PathVariable("username") username: String): Boolean = employeeService.isUserAvailable(username)
+
+    @GetMapping("{username}/manager")
+    @PreAuthorize("@employeeServicePermissionEvaluator.hasPermission('ACCESS_EMPLOYEE')")
+    fun getManager(@PathVariable("username") username: String): ManagerDTO = employeeService.getManager(username)
 }

--- a/server/src/main/kotlin/org/octopusden/employee/service/AdService.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/AdService.kt
@@ -1,0 +1,11 @@
+package org.octopusden.employee.service
+
+import org.octopusden.employee.client.common.exception.NotFoundException
+
+interface AdService {
+    /**
+     * Returns the manager's sAMAccountName, or null if the user has no manager attribute.
+     * Throws [NotFoundException] if [username] is not found in AD.
+     */
+    fun getManager(username: String): String?
+}

--- a/server/src/main/kotlin/org/octopusden/employee/service/EmployeeService.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/EmployeeService.kt
@@ -1,6 +1,7 @@
 package org.octopusden.employee.service
 
 import org.octopusden.employee.client.common.dto.Employee
+import org.octopusden.employee.client.common.dto.ManagerDTO
 import org.octopusden.employee.client.common.dto.RequiredTimeDTO
 import org.octopusden.employee.client.common.dto.WorkingDaysDTO
 import java.time.LocalDate
@@ -11,4 +12,5 @@ interface EmployeeService {
     fun isUserAvailable(username: String): Boolean
     fun getEmployeeAvailableEarlier(employees: Set<String>): Employee
     fun getWorkingDays(fromDate: LocalDate, toDate: LocalDate): WorkingDaysDTO
+    fun getManager(username: String): ManagerDTO
 }

--- a/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
@@ -6,10 +6,12 @@ import org.octopusden.employee.service.AdService
 import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.ldap.NameNotFoundException
 import org.springframework.ldap.core.AttributesMapper
 import org.springframework.ldap.core.LdapTemplate
 import org.springframework.ldap.query.LdapQueryBuilder
 import org.springframework.stereotype.Service
+import javax.naming.InvalidNameException
 import javax.naming.ldap.LdapName
 
 @Service
@@ -34,11 +36,19 @@ class AdServiceImpl(
 
         val managerDn: String = results.first() ?: return null
 
-        return ldapTemplate.lookup(
-            LdapName(managerDn),
-            arrayOf("sAMAccountName"),
-            AttributesMapper { attrs -> attrs.get("sAMAccountName")?.get()?.toString() },
-        )
+        return try {
+            ldapTemplate.lookup(
+                LdapName(managerDn),
+                arrayOf("sAMAccountName"),
+                AttributesMapper { attrs -> attrs.get("sAMAccountName")?.get()?.toString() },
+            )
+        } catch (e: NameNotFoundException) {
+            log.warn("Manager DN '{}' for user '{}' not found in AD", managerDn, username)
+            null
+        } catch (e: InvalidNameException) {
+            log.warn("Invalid manager DN '{}' for user '{}'", managerDn, username)
+            null
+        }
     }
 
     companion object {

--- a/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
@@ -28,6 +28,7 @@ class AdServiceImpl(
         val results = ldapTemplate.search(
             LdapQueryBuilder.query()
                 .base(adProperties.baseDn)
+                .attributes(ATTR_MANAGER)
                 .where(ATTR_SAM_ACCOUNT_NAME).`is`(username),
             AttributesMapper { attrs -> attrs.get(ATTR_MANAGER)?.get()?.toString() },
         )

--- a/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
@@ -21,15 +21,15 @@ class AdServiceImpl(
     private val adProperties: AdProperties,
 ) : AdService {
 
-    @Cacheable("managers")
+    @Cacheable(CACHE_MANAGERS)
     override fun getManager(username: String): String? {
         log.debug("getManager({})", username)
 
         val results = ldapTemplate.search(
             LdapQueryBuilder.query()
                 .base(adProperties.baseDn)
-                .where("sAMAccountName").`is`(username),
-            AttributesMapper { attrs -> attrs.get("manager")?.get()?.toString() },
+                .where(ATTR_SAM_ACCOUNT_NAME).`is`(username),
+            AttributesMapper { attrs -> attrs.get(ATTR_MANAGER)?.get()?.toString() },
         )
 
         if (results.isEmpty()) throw NotFoundException("User '$username' not found in AD")
@@ -39,8 +39,8 @@ class AdServiceImpl(
         return try {
             ldapTemplate.lookup(
                 LdapName(managerDn),
-                arrayOf("sAMAccountName"),
-                AttributesMapper { attrs -> attrs.get("sAMAccountName")?.get()?.toString() },
+                arrayOf(ATTR_SAM_ACCOUNT_NAME),
+                AttributesMapper { attrs -> attrs.get(ATTR_SAM_ACCOUNT_NAME)?.get()?.toString() },
             )
         } catch (e: NameNotFoundException) {
             log.warn("Manager DN '{}' for user '{}' not found in AD", managerDn, username)
@@ -52,6 +52,9 @@ class AdServiceImpl(
     }
 
     companion object {
+        const val ATTR_SAM_ACCOUNT_NAME = "sAMAccountName"
+        const val ATTR_MANAGER = "manager"
+        const val CACHE_MANAGERS = "managers"
         private val log = LoggerFactory.getLogger(AdServiceImpl::class.java)
     }
 }

--- a/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/impl/AdServiceImpl.kt
@@ -1,0 +1,47 @@
+package org.octopusden.employee.service.impl
+
+import org.octopusden.employee.client.common.exception.NotFoundException
+import org.octopusden.employee.config.AdProperties
+import org.octopusden.employee.service.AdService
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.ldap.core.AttributesMapper
+import org.springframework.ldap.core.LdapTemplate
+import org.springframework.ldap.query.LdapQueryBuilder
+import org.springframework.stereotype.Service
+import javax.naming.ldap.LdapName
+
+@Service
+@ConditionalOnProperty("ad.url")
+class AdServiceImpl(
+    private val ldapTemplate: LdapTemplate,
+    private val adProperties: AdProperties,
+) : AdService {
+
+    @Cacheable("managers")
+    override fun getManager(username: String): String? {
+        log.debug("getManager({})", username)
+
+        val results = ldapTemplate.search(
+            LdapQueryBuilder.query()
+                .base(adProperties.baseDn)
+                .where("sAMAccountName").`is`(username),
+            AttributesMapper { attrs -> attrs.get("manager")?.get()?.toString() },
+        )
+
+        if (results.isEmpty()) throw NotFoundException("User '$username' not found in AD")
+
+        val managerDn: String = results.first() ?: return null
+
+        return ldapTemplate.lookup(
+            LdapName(managerDn),
+            arrayOf("sAMAccountName"),
+            AttributesMapper { attrs -> attrs.get("sAMAccountName")?.get()?.toString() },
+        )
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(AdServiceImpl::class.java)
+    }
+}

--- a/server/src/main/kotlin/org/octopusden/employee/service/impl/EmployeeServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/impl/EmployeeServiceImpl.kt
@@ -90,7 +90,10 @@ class EmployeeServiceImpl(
 
     override fun getManager(username: String): ManagerDTO {
         log.debug("getManager({})", username)
-        val svc = adService.getIfAvailable() ?: return ManagerDTO(null)
+        val svc = adService.getIfAvailable() ?: run {
+            checkUserExists(username)
+            return ManagerDTO(null)
+        }
         return ManagerDTO(svc.getManager(username))
     }
 

--- a/server/src/main/kotlin/org/octopusden/employee/service/impl/EmployeeServiceImpl.kt
+++ b/server/src/main/kotlin/org/octopusden/employee/service/impl/EmployeeServiceImpl.kt
@@ -2,10 +2,12 @@ package org.octopusden.employee.service.impl
 
 import org.apache.http.HttpStatus
 import org.octopusden.employee.client.common.dto.Employee
+import org.octopusden.employee.client.common.dto.ManagerDTO
 import org.octopusden.employee.client.common.dto.RequiredTimeDTO
 import org.octopusden.employee.client.common.dto.WorkingDaysDTO
 import org.octopusden.employee.client.common.exception.NotFoundException
 import org.octopusden.employee.config.EmployeeServiceProperties
+import org.octopusden.employee.service.AdService
 import org.octopusden.employee.service.EmployeeService
 import org.octopusden.employee.service.OneCService
 import org.octopusden.employee.service.formatJQL
@@ -15,6 +17,7 @@ import org.octopusden.employee.service.jira.client.jira1.Jira1Client
 import org.octopusden.employee.service.jira.client.jira2.Jira2Client
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -23,7 +26,8 @@ class EmployeeServiceImpl(
     private val oneCService: OneCService,
     private val jira1Client: Jira1Client,
     private val jira2Client: Jira2Client,
-    private val employeeServiceProperties: EmployeeServiceProperties
+    private val employeeServiceProperties: EmployeeServiceProperties,
+    private val adService: ObjectProvider<AdService>,
 ) :
     EmployeeService {
 
@@ -82,6 +86,12 @@ class EmployeeServiceImpl(
     override fun getWorkingDays(fromDate: LocalDate, toDate: LocalDate): WorkingDaysDTO {
         return oneCService.getWorkingDays(fromDate, toDate)
             .also { workingDaysDTO -> log.debug("getWorkingDays($fromDate,$toDate)=$workingDaysDTO") }
+    }
+
+    override fun getManager(username: String): ManagerDTO {
+        log.debug("getManager({})", username)
+        val svc = adService.getIfAvailable() ?: return ManagerDTO(null)
+        return ManagerDTO(svc.getManager(username))
     }
 
     data class UserAbsence(val employee: JiraUser, val start: LocalDate, val end: LocalDate)

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,9 +1,4 @@
 spring.mvc.pathmatch.matching-strategy: ant_path_matcher
-spring:
-  cache:
-    type: caffeine
-    caffeine:
-      spec: maximumSize=1000,expireAfterWrite=300s
 management:
   endpoint:
     health:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,4 +1,9 @@
 spring.mvc.pathmatch.matching-strategy: ant_path_matcher
+spring:
+  cache:
+    type: caffeine
+    caffeine:
+      spec: maximumSize=1000,expireAfterWrite=300s
 management:
   endpoint:
     health:

--- a/server/src/test/kotlin/org/octopusden/employee/EmployeeControllerTest.kt
+++ b/server/src/test/kotlin/org/octopusden/employee/EmployeeControllerTest.kt
@@ -4,13 +4,21 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.octopusden.employee.client.common.dto.Employee
 import org.octopusden.employee.client.common.dto.ErrorResponse
+import org.octopusden.employee.client.common.dto.ManagerDTO
 import org.octopusden.employee.client.common.dto.RequiredTimeDTO
+import org.octopusden.employee.client.common.exception.NotFoundException
+import org.octopusden.employee.service.AdService
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.doThrow
+import org.mockito.Mockito.`when`
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.security.test.context.support.WithMockUser
@@ -38,6 +46,9 @@ class EmployeeControllerTest : BaseEmployeeControllerTest() {
 
     @Autowired
     private lateinit var mapper: ObjectMapper
+
+    @MockBean
+    private lateinit var adService: AdService
 
     @BeforeAll
     fun beforeAllRepositoryControllerTests() {
@@ -88,6 +99,45 @@ class EmployeeControllerTest : BaseEmployeeControllerTest() {
             .response
             .contentAsString!!
             .toBoolean()
+
+    @Test
+    fun getManagerWithManager() {
+        `when`(adService.getManager("employee")).thenReturn("manager")
+        val result = mvc.perform(
+            MockMvcRequestBuilders.get("/employee/{username}/manager", "employee")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+            .response
+            .toObject(object : TypeReference<ManagerDTO>() {})
+        Assertions.assertEquals(ManagerDTO("manager"), result)
+    }
+
+    @Test
+    fun getManagerWithNoManager() {
+        `when`(adService.getManager("employee")).thenReturn(null)
+        val result = mvc.perform(
+            MockMvcRequestBuilders.get("/employee/{username}/manager", "employee")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andReturn()
+            .response
+            .toObject(object : TypeReference<ManagerDTO>() {})
+        Assertions.assertEquals(ManagerDTO(null), result)
+    }
+
+    @Test
+    fun getManagerUserNotFound() {
+        doThrow(NotFoundException("User 'nonexistent' not found in AD"))
+            .`when`(adService).getManager("nonexistent")
+        mvc.perform(
+            MockMvcRequestBuilders.get("/employee/{username}/manager", "nonexistent")
+                .accept(MediaType.APPLICATION_JSON)
+        )
+            .andExpect(MockMvcResultMatchers.status().isNotFound)
+    }
 
     private fun <T> MockHttpServletResponse.toObject(typeReference: TypeReference<T>): T =
         mapper.readValue(this.contentAsByteArray, typeReference)

--- a/server/src/test/kotlin/org/octopusden/employee/service/impl/AdServiceImplTest.kt
+++ b/server/src/test/kotlin/org/octopusden/employee/service/impl/AdServiceImplTest.kt
@@ -1,0 +1,72 @@
+package org.octopusden.employee.service.impl
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.octopusden.employee.client.common.exception.NotFoundException
+import org.octopusden.employee.config.AdProperties
+import org.springframework.ldap.NameNotFoundException
+import org.springframework.ldap.core.AttributesMapper
+import org.springframework.ldap.core.LdapTemplate
+import org.springframework.ldap.query.LdapQuery
+import javax.naming.Name
+
+class AdServiceImplTest {
+
+    private val ldapTemplate = Mockito.mock(LdapTemplate::class.java)
+    private val adProperties = AdProperties(baseDn = "OU=Users,DC=example,DC=com")
+    private val adService = AdServiceImpl(ldapTemplate, adProperties)
+
+    @Test
+    fun getManagerReturnsManagerUsername() {
+        stubSearch(listOf("CN=Manager,OU=Users,DC=example,DC=com"))
+        stubLookup("managerSam")
+
+        Assertions.assertEquals("managerSam", adService.getManager("employee"))
+    }
+
+    @Test
+    fun getManagerReturnsNullWhenUserHasNoManagerAttribute() {
+        stubSearch(listOf(null))
+
+        Assertions.assertNull(adService.getManager("employee"))
+        Mockito.verify(ldapTemplate, Mockito.never())
+            .lookup(any(Name::class.java), any<Array<String>>(), any<AttributesMapper<String?>>())
+    }
+
+    @Test
+    fun getManagerThrowsNotFoundWhenUserMissing() {
+        stubSearch(emptyList())
+
+        Assertions.assertThrows(NotFoundException::class.java) { adService.getManager("nobody") }
+    }
+
+    @Test
+    fun getManagerReturnsNullWhenManagerDnIsStale() {
+        stubSearch(listOf("CN=Ghost,OU=Users,DC=example,DC=com"))
+        Mockito.`when`(ldapTemplate.lookup(any(Name::class.java), any<Array<String>>(), any<AttributesMapper<String?>>()))
+            .thenThrow(NameNotFoundException("not found"))
+
+        Assertions.assertNull(adService.getManager("employee"))
+    }
+
+    @Test
+    fun getManagerReturnsNullWhenManagerDnIsMalformed() {
+        stubSearch(listOf("not-a-valid-dn-no-equals"))
+
+        Assertions.assertNull(adService.getManager("employee"))
+        Mockito.verify(ldapTemplate, Mockito.never())
+            .lookup(any(Name::class.java), any<Array<String>>(), any<AttributesMapper<String?>>())
+    }
+
+    private fun stubSearch(result: List<String?>) {
+        Mockito.`when`(ldapTemplate.search(any<LdapQuery>(), any<AttributesMapper<String?>>()))
+            .thenReturn(result)
+    }
+
+    private fun stubLookup(result: String?) {
+        Mockito.`when`(ldapTemplate.lookup(any(Name::class.java), any<Array<String>>(), any<AttributesMapper<String?>>()))
+            .thenReturn(result)
+    }
+}

--- a/server/src/test/kotlin/org/octopusden/employee/service/impl/EmployeeServiceImplGetManagerTest.kt
+++ b/server/src/test/kotlin/org/octopusden/employee/service/impl/EmployeeServiceImplGetManagerTest.kt
@@ -1,0 +1,54 @@
+package org.octopusden.employee.service.impl
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.octopusden.employee.client.common.dto.ManagerDTO
+import org.octopusden.employee.client.common.exception.NotFoundException
+import org.octopusden.employee.config.EmployeeServiceProperties
+import org.octopusden.employee.service.AdService
+import org.octopusden.employee.service.OneCService
+import org.octopusden.employee.service.jira.client.common.JiraClientException
+import org.octopusden.employee.service.jira.client.common.JiraUser
+import org.octopusden.employee.service.jira.client.jira1.Jira1Client
+import org.octopusden.employee.service.jira.client.jira2.Jira2Client
+import org.springframework.beans.factory.ObjectProvider
+
+class EmployeeServiceImplGetManagerTest {
+
+    private val jira1Client = Mockito.mock(Jira1Client::class.java)
+    private val adServiceProvider = Mockito.mock(ObjectProvider::class.java) as ObjectProvider<AdService>
+    private val employeeService = EmployeeServiceImpl(
+        Mockito.mock(OneCService::class.java),
+        jira1Client,
+        Mockito.mock(Jira2Client::class.java),
+        EmployeeServiceProperties(8, EmployeeServiceProperties.UserAvailability("")),
+        adServiceProvider,
+    )
+
+    @Test
+    fun getManagerReturnsNullWhenAdIsNotConfiguredAndUserExists() {
+        Mockito.`when`(adServiceProvider.getIfAvailable()).thenReturn(null)
+        Mockito.`when`(jira1Client.getUser("employee")).thenReturn(JiraUser("employee", "employee@example.local", "Employee", true))
+
+        Assertions.assertEquals(ManagerDTO(null), employeeService.getManager("employee"))
+    }
+
+    @Test
+    fun getManagerThrowsNotFoundWhenAdIsNotConfiguredAndUserDoesNotExist() {
+        Mockito.`when`(adServiceProvider.getIfAvailable()).thenReturn(null)
+        Mockito.`when`(jira1Client.getUser("nobody")).thenThrow(JiraClientException(404, "not found"))
+
+        Assertions.assertThrows(NotFoundException::class.java) { employeeService.getManager("nobody") }
+    }
+
+    @Test
+    fun getManagerDelegatesToAdServiceWhenConfigured() {
+        val adService = Mockito.mock(AdService::class.java)
+        Mockito.`when`(adServiceProvider.getIfAvailable()).thenReturn(adService)
+        Mockito.`when`(adService.getManager("employee")).thenReturn("managerSam")
+
+        Assertions.assertEquals(ManagerDTO("managerSam"), employeeService.getManager("employee"))
+        Mockito.verifyNoInteractions(jira1Client)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `GET /employee/{username}/manager` endpoint that returns the manager's username for a given employee
- Manager data is resolved via a two-step directory lookup: employee username → manager DN → manager username
- New `ManagerDTO(manager: String?)` in the common module; `null` means the employee has no manager configured
- AD/LDAP integration is **opt-in** via `ad.url` property (`@ConditionalOnProperty`) — deployments without AD configured get `ManagerDTO(null)` transparently
- Caffeine cache on the lookup (TTL 5 min, max 1 000 entries) to avoid repeated round-trips

## Changes

| Module | What changed |
|---|---|
| `common` | New `ManagerDTO` DTO |
| `client` | `getManager()` added to `EmployeeServiceClient` interface and `ClassicEmployeeServiceClient` |
| `server` | `AdProperties`, `AdConfig` (conditional LDAP config), `AdService` interface, `AdServiceImpl` (two-step lookup + cache), `EmployeeService.getManager()`, controller endpoint |
| `server/build.gradle.kts` | `spring-ldap-core`, `spring-boot-starter-cache`, `caffeine` dependencies |

## Configuration

Non-sensitive properties (set in config service):
```yaml
ad:
  url: ldap://<host>:389
  user-dn: <bind-user>
  base-dn: OU=Users,DC=example,DC=com
```

Credential (`ad.password`) goes into Vault.

When `ad.url` is absent the endpoint still responds with `{"manager": null}`.

## Test plan

- [ ] `getManagerWithManager` — mocked `AdService` returns a username → response is `{"manager": "username"}`
- [ ] `getManagerWithNoManager` — mocked `AdService` returns `null` → response is `{"manager": null}`
- [ ] `getManagerUserNotFound` — mocked `AdService` throws `NotFoundException` → HTTP 404
- [ ] Existing `EmployeeControllerTest` suite passes unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secured endpoint to retrieve an employee’s manager: `GET /employee/{username}/manager`.
  * Extended the service client and shared response model to support manager lookups.
* **Bug Fixes**
  * Improved behavior when manager info is unavailable (returns an empty manager value instead of failing).
  * Returns a clear not-found response when the employee doesn’t exist.
* **Tests**
  * Added coverage for manager found, no manager, and employee not found scenarios.
  * Added LDAP/AD manager lookup tests and service delegation tests.
* **Chores**
  * Enabled cached manager lookups when directory configuration is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->